### PR TITLE
Pin papilo to v2.0.0

### DIFF
--- a/org.flatcam.FlatCAM.yml
+++ b/org.flatcam.FlatCAM.yml
@@ -878,7 +878,7 @@ modules:
             sources:
               - type: git
                 url: https://github.com/scipopt/papilo.git
-                branch: develop
+                tag: v2.0.0
           - name: soplex
             buildsystem: cmake-ninja
             sources:


### PR DESCRIPTION
Hi there, I tried building your flatpak today and was met with Boost errors from the papilo library. I tried many CMake flags to get it to build but in the end found that using a slightly older version of Papilo works just fine.

If you diff papilo's CMakeLists file you can see that they have recently changed the Boost config. v2.0.0 does not have the boost config change.

This PR simply pins the papilo dependency to the `v2.0.0` tag, rather than building from the latest changes in their `develop` branch.